### PR TITLE
fix(notes): correct some typos of the class notes

### DIFF
--- a/aulas/aula02/notes.md
+++ b/aulas/aula02/notes.md
@@ -12,7 +12,7 @@
     | ---------- | ------- | ------------------- |
     | $t0 a $t7  | 8-15    | 8 regs. temporários |
     | $s0 a $s7  | 16-23   | 8 regs. salvos      |
-    | $st8 e $t9 | 24 e 25 | 2 regs. temporários |
+    | $t8 e $t9 | 24 e 25 | 2 regs. temporários |
     | Restante   |  `---`  | Uso reservado       |
 
 ### Operações aritméticas

--- a/aulas/aula04/notes.md
+++ b/aulas/aula04/notes.md
@@ -1,7 +1,7 @@
 ## Instruções de acesso à memória
 
 - A memória é um "vetor" com células de 1 byte
-- `ld reg1, const (reg2)` - minemónio de leitura
+- `lw reg1, const (reg2)` - minemónio de leitura
     - load word
     - lê o conteúdo da memória do endereço *reg2 + const*
 


### PR DESCRIPTION
**What's being changed:**
- Register $st8 does not exist, the correct one is $t8
- The `ld` instruction should be `lw`