### PR TITLE
fix(code): adds important syscall to the example to make it correct

### DIFF
--- a/aulas/aula08/notes.md
+++ b/aulas/aula08/notes.md
@@ -84,7 +84,7 @@ b = $s1
 
 .text
 main:
-    li $s0, 3
+    li $s0, 1
     li $s1, 2
 
     # Carrega args.

--- a/aulas/aula08/notes.md
+++ b/aulas/aula08/notes.md
@@ -107,6 +107,10 @@ main:
     la $a0, nl
     syscall
 
+    # Finaliza a execução
+    li $v0, 10
+    syscall
+
 media:
     add $t0, $a0, $a1 # t0 = a + b
     srl $v0, $t0, 1 # v0 = t0 / 2


### PR DESCRIPTION
**What's being changed:**
- Add `syscall 10` to finish `aulas/aula08/notes.md` code execution.
- Change `a` variable value of `3` to `1` making code equal to the [C example above](https://github.com/caio-felipee/fac/blob/main/aulas/aula08/notes.md#retorna-ao-chamador).